### PR TITLE
Add tokenix.finance and its subdomains to whitelist

### DIFF
--- a/whitelist.yaml
+++ b/whitelist.yaml
@@ -30,3 +30,5 @@
   - url: "*.tistory.com"
   - url: "*.surge.sh"
   - url: revoke.cash
+  - url: "tokenix.finance"
+  - url: "*.tokenix.finance"


### PR DESCRIPTION
This pull request adds the domain tokenix.finance and all its subdomains to the whitelist. The following entries have been added to the whitelist.yaml file: Reason for Whitelisting:
tokenix.finance is a legitimate and secure platform dedicated to providing reliable financial services to its users. The domain and its subdomains are essential for the operation of our services, and being blocked by Phantom is causing significant disruption to our users. We have taken all necessary measures to ensure the security and integrity of our platform. We believe that whitelisting tokenix.finance and its subdomains will enhance the user experience and prevent any further inconvenience. Additional Information:
The domain tokenix.finance is not associated with any malicious activities. We have implemented robust security protocols to protect our users. Our platform is trusted by a growing community of users who rely on our services. We kindly request the Phantom team to review and approve this pull request at the earliest convenience. Thank you for your attention and support.